### PR TITLE
Support symbols and support inspection

### DIFF
--- a/lib/registry/injector.js
+++ b/lib/registry/injector.js
@@ -32,6 +32,8 @@
 
 'use strict';
 
+const util = require('util');
+
 const { parseDependencyQuery } = require('./query');
 
 /** @typedef {import('../typedefs').Scope} Scope */
@@ -39,18 +41,39 @@ const { parseDependencyQuery } = require('./query');
 /** @typedef {import('../typedefs').DependencyDescriptor} DependencyDescriptor */
 /** @typedef {import('../typedefs').DependencyQuery} DependencyQuery */
 
+const INSPECT = util.inspect.custom || Symbol.for('nodejs.util.inspect.custom');
+
+/**
+ * @param {Injector} injector
+ */
+function inspectProvider(injector) {
+  // @ts-ignore
+  return `Provider { ${injector[INSPECT]()} }`;
+}
+
 const PROVIDER_HANDLER = {
   /**
    * @param {Injector} injector
-   * @param {string} key
+   * @param {string | symbol} key
    */
   get(injector, key) {
-    if (key === 'get') {
-      return injector.get;
-    } else if (key === 'keys') {
-      return injector.keys;
+    switch (key) {
+      case 'constructor':
+        return injector.constructor;
+
+      case 'get':
+        return injector.get;
+
+      case 'keys':
+        return injector.keys;
+
+      case INSPECT: {
+        return inspectProvider.bind(null, injector);
+      }
+
+      default:
+        return injector.get(key);
     }
-    return injector.get(key);
   },
 
   set(/* injector, key, value */) {
@@ -71,7 +94,7 @@ const PROVIDER_HANDLER = {
 
   ownKeys() {
     // Mask implementation details like `scope` and `state`
-    return ['get', 'keys'];
+    return ['get', 'keys', INSPECT];
   },
 };
 
@@ -82,6 +105,15 @@ const PROVIDER_HANDLER = {
  */
 
 /** @typedef {{ [key: string]: unknown } & ProviderMethods} Provider */
+
+/**
+ * @param {symbol | string} symbolOrString
+ */
+function toString(symbolOrString) {
+  return typeof symbolOrString === 'symbol'
+    ? symbolOrString.toString()
+    : String(symbolOrString);
+}
 
 class Injector {
   /**
@@ -99,8 +131,14 @@ class Injector {
     this.get = this._get.bind(this);
   }
 
+  [INSPECT]() {
+    return `Injector<${this.scope.name}> { ${this.keys()
+      .map(toString)
+      .join(', ')} }`;
+  }
+
   _keys() {
-    /** @type {string[]} */
+    /** @type {(string | symbol)[]} */
     const scopeKeys = [];
     /** @type {Injector | null} */
     let injector;
@@ -112,7 +150,7 @@ class Injector {
   }
 
   /**
-   * @param {string} key
+   * @param {string | symbol} key
    */
   _collectMultiValuedProviders(key) {
     /** @type {Map<string, any>} */
@@ -160,7 +198,7 @@ class Injector {
   }
 
   /**
-   * @param {string | DependencyDescriptor} query
+   * @param {string | symbol | DependencyDescriptor} query
    * @returns {unknown}
    */
   _get(query) {
@@ -194,7 +232,7 @@ class Injector {
       this.state.set(key, []);
       return [];
     }
-    throw Object.assign(new Error(`Unknown dependency key ${key}`), {
+    throw Object.assign(new Error(`Unknown dependency key ${toString(key)}`), {
       code: 'INVALID_DEPENDENCY_KEY',
       scope: this.scope.name,
     });

--- a/lib/registry/query.js
+++ b/lib/registry/query.js
@@ -73,6 +73,9 @@ const queryStringCache = new Map();
  * @returns {DependencyDescriptor}
  */
 function parseDependencyQuery(query) {
+  if (typeof query === 'symbol') {
+    return { key: query, optional: false, multiValued: false };
+  }
   if (typeof query !== 'string') return query;
   let descriptor = queryStringCache.get(query);
   if (!descriptor) {

--- a/lib/registry/scope.js
+++ b/lib/registry/scope.js
@@ -67,6 +67,15 @@ function createMultiValued(initialValues = []) {
   });
 }
 
+/**
+ * @param {symbol | string} symbolOrString
+ */
+function toString(symbolOrString) {
+  return typeof symbolOrString === 'symbol'
+    ? symbolOrString.toString()
+    : String(symbolOrString);
+}
+
 class Scope {
   /**
    * @param {string} name
@@ -74,7 +83,7 @@ class Scope {
   constructor(name) {
     this.name = name;
     /**
-     * @type {Map<string, DependencyProvider>}
+     * @type {Map<string | symbol, DependencyProvider>}
      */
     this.known = new Map();
     this.cacheKey = Symbol(`di-namespace:${name}`);
@@ -118,7 +127,7 @@ class Scope {
     if (!dependeny.multiValued || !dependeny.index) {
       throw Object.assign(
         new Error(
-          `Setting a multi-valued provider for ${key} in ${
+          `Setting a multi-valued provider for ${toString(key)} in ${
             this.name
           } requires an index`
         ),
@@ -137,7 +146,7 @@ class Scope {
       if (!isMultiValued(previous)) {
         throw Object.assign(
           new Error(
-            `${key} in ${
+            `${toString(key)} in ${
               this.name
             } has already been registered as single-valued`
           ),
@@ -152,7 +161,7 @@ class Scope {
       if (previous.has(dependeny.index)) {
         throw Object.assign(
           new Error(
-            `${key}[${dependeny.index}] in ${
+            `${toString(key)}[${dependeny.index}] in ${
               this.name
             } has already been registered`
           ),
@@ -199,7 +208,9 @@ class Scope {
     if (this.known.has(key)) {
       throw Object.assign(
         new Error(
-          `A provider for ${key} has already been registered in ${this.name}`
+          `A provider for ${toString(key)} has already been registered in ${
+            this.name
+          }`
         ),
         {
           code: 'DUPLICATE_DEPENDENCY_KEY',

--- a/lib/typedefs.d.ts
+++ b/lib/typedefs.d.ts
@@ -1,13 +1,13 @@
 import { IncomingMessage, ServerResponse } from 'http';
 
 type DependencyDescriptor = {
-  key: string,
+  key: string | symbol,
   index?: string,
   optional?: boolean,
   multiValued?: boolean,
 };
 
-type DependencyQuery = DependencyDescriptor | string;
+type DependencyQuery = DependencyDescriptor | string | symbol;
 
 type PackageJSON = {
   name: string;
@@ -31,21 +31,21 @@ declare class Scope {
 
   readonly name: string;
 
-  setFactory<T>(query: string, deps: string[] | null, factory: (deps?: any) => T): void;
+  setFactory<T>(query: string | symbol, deps: string[] | null, factory: (deps?: any) => T): void;
 
   createInjector(init: Map<any, any>, parent?: Injector): Injector;
   getCachedInjector(target: object): Injector;
   getCachedInjector(target: object, init: Map<any, any>, parent: Injector): Injector;
-  create<T>(key: string, injector: Injector): T;
+  create<T>(key: string | symbol, injector: Injector): T;
 
-  has(key: string): boolean;
-  getKeys(): string[];
-  getOwnMultiValuedProviders(key: string): MultiValuedDependencyProvider;
+  has(key: string | symbol): boolean;
+  getKeys(): (string | symbol)[];
+  getOwnMultiValuedProviders(key: string | symbol): MultiValuedDependencyProvider;
 }
 
 type Provider = {
   get(query: DependencyQuery): unknown;
-  keys(): string[];
+  keys(): (string | symbol)[];
 
   [key: string]: unknown;
 };


### PR DESCRIPTION
This kept annoying me: Now it's safe to `console.log` or evaluate in a repl without having to worry about bad proxy traps leading to exceptions. We're also cleanly handling symbols in general now. Previously `deps[Symbol('x')]` would print a cryptic "undefined could not be created" because it tried to read `Symbol('x').key` as the dependency key to look up.