### PR TITLE
Expose object-graph info

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,12 @@ each assuming that the resulting dependency is called `x`:
   When providing a multi-valued dependency, this form has to be used.
   Descriptor: `{ key: 'x', multiValued: true, index: 'y' }`.
 
+#### `registry.getProviderGraph()`
+
+Returns a structured object with information about all registered providers,
+where they have been registered, and what their dependencies are.
+This data can be used to provide inspection and other developer tooling.
+
 #### `registry.getSingletonInjector()`
 
 Creates an `Injector` for the `singleton` scope.

--- a/examples/project/modules/answer/object-graph.js
+++ b/examples/project/modules/answer/object-graph.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = (/** @type {import('../../../../').Registry} */ registry) => {
+  registry.singleton.setFactory('base', null, () => 21);
+
+  registry.request.setFactory('factor', null, () => 2);
+
+  registry.action.setFactory(
+    'answer',
+    ['base', 'factor'],
+    ({ base, factor }) => base * factor
+  );
+
+  registry.singleton.setFactory('spoilers[answer]', null, () => 42);
+};

--- a/lib/app.js
+++ b/lib/app.js
@@ -35,6 +35,8 @@
 const Project = require('./project');
 const Registry = require('./registry');
 
+const dumpObjectGraph = require('./commands/dump-object-graph');
+
 /**
  * @param {App} app
  */
@@ -49,6 +51,10 @@ async function initializeApp(app) {
     }
     provider(app.registry);
   }
+
+  app.registry.singleton.setFactory('commands[dump-object-graph]', null, () => {
+    return dumpObjectGraph;
+  });
 }
 
 /**

--- a/lib/commands/dump-object-graph.js
+++ b/lib/commands/dump-object-graph.js
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2019, Groupon
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+'use strict';
+
+/**
+ * @typedef DumpObjectGraphOptions
+ * @prop {boolean} json
+ */
+
+/**
+ * @param {string} propKey
+ * @param {unknown} propValue
+ */
+function convertMaps(propKey, propValue) {
+  if (propValue instanceof Map) {
+    const output = /** @type {{ [key: string]: any }} */ ({});
+    for (const [key, value] of propValue) {
+      output[key.toString()] = value;
+    }
+    return output;
+  }
+  return propValue;
+}
+
+module.exports = /** @type {import('../typedefs').CommandConfig<DumpObjectGraphOptions>} */ ({
+  name: 'dump-object-graph',
+  description: 'Dump known object graph providers and their dependencies',
+
+  init(cmd) {
+    cmd.option('--json', 'Print the raw data as JSON');
+  },
+
+  async action(app, options) {
+    const data = app.registry.getProviderGraph();
+    if (options.json) {
+      process.stdout.write(`${JSON.stringify(data, convertMaps)}\n`);
+      return 0;
+    }
+
+    throw new Error(
+      'Pretty printing is not implemented yet, please use --json'
+    );
+  },
+});

--- a/lib/main.js
+++ b/lib/main.js
@@ -34,14 +34,9 @@
 
 const Commander = require('commander');
 
-/** @typedef {import('./app')} App */
-
 /**
- * @typedef CommandConfig
- * @prop {string} name
- * @prop {string} description
- * @prop {(cmd: import('commander').Command) => void} init
- * @prop {(app: App, options: any, ...args: any[]) => Promise<number | void>} action
+ * @typedef {import('./app')} App
+ * @typedef {import('./typedefs').CommandConfig<any>} CommandConfig
  */
 
 /**

--- a/lib/registry/index.js
+++ b/lib/registry/index.js
@@ -34,11 +34,38 @@
 
 const Scope = require('./scope');
 
+/**
+ * @typedef {import('../typedefs').ScopeNode} ScopeNode
+ */
+
 class Registry {
   constructor() {
     this.singleton = new Scope('singleton');
     this.request = new Scope('request');
     this.action = new Scope('action');
+  }
+
+  /**
+   * @returns {ScopeNode}
+   */
+  getProviderGraph() {
+    const action = {
+      name: 'action',
+      providers: this.action.getProviderNodes(),
+      children: [],
+    };
+    const request = {
+      name: 'request',
+      providers: this.request.getProviderNodes(),
+      children: [action],
+    };
+    const singleton = {
+      name: 'singleton',
+      providers: this.singleton.getProviderNodes(),
+      children: [request],
+    };
+
+    return singleton;
   }
 
   getSingletonInjector() {

--- a/lib/registry/scope.js
+++ b/lib/registry/scope.js
@@ -40,6 +40,9 @@ const { parseDependencyQuery } = require('./query');
  * @typedef {import('../typedefs').SimpleDependencyProvider} SimpleDependencyProvider
  * @typedef {import('../typedefs').MultiValuedDependencyProvider} MultiValuedDependencyProvider
  * @typedef {import('../typedefs').DependencyProvider} DependencyProvider
+ * @typedef {import('../typedefs').DependencyDescriptor} DependencyDescriptor
+ * @typedef {import('../typedefs').ProviderNode} ProviderNode
+ * @typedef {import('../typedefs').SimpleProviderNode} SimpleProviderNode
  */
 
 const MULTI_VALUED = Symbol('isMultiValued');
@@ -74,6 +77,52 @@ function toString(symbolOrString) {
   return typeof symbolOrString === 'symbol'
     ? symbolOrString.toString()
     : String(symbolOrString);
+}
+
+const STACK_HOLDER = { stack: '' };
+
+/**
+ * @param {function} setFactory
+ * @param {null | DependencyDescriptor[]} dependencies
+ */
+function getProviderMetaData(setFactory, dependencies) {
+  Error.captureStackTrace(STACK_HOLDER, setFactory);
+  const stack = STACK_HOLDER.stack || '';
+  const [, filename = '<unknown>', lineNumber = 0, columnNumber = 0] =
+    stack
+      .slice(stack.indexOf('\n') + 1)
+      .match(/^[^(]+\(([^:]+):([^:]+):([^)]+)\)/) || [];
+  return {
+    dependencies,
+    location: {
+      filename,
+      line: +lineNumber,
+      column: +columnNumber,
+    },
+  };
+}
+
+/**
+ * @param {string | symbol} key
+ * @param {any} provider
+ * @returns {ProviderNode}
+ */
+function getProviderNode(key, provider) {
+  if (provider instanceof Map) {
+    return {
+      key,
+      multiValued: true,
+      indices: new Map(
+        Array.from(provider.entries()).map(([index, actual]) => {
+          return /** @type {[string, SimpleProviderNode]} */ ([
+            index,
+            getProviderNode(index, actual),
+          ]);
+        })
+      ),
+    };
+  }
+  return Object.assign({ key, multiValued: false }, provider);
 }
 
 class Scope {
@@ -201,6 +250,9 @@ class Scope {
         }
       : () => factory();
 
+    // Annotate provider
+    Object.assign(provider, getProviderMetaData(this.setFactory, parsedDeps));
+
     if (dependeny.multiValued) {
       return void this.multiSet(dependeny, provider);
     }
@@ -278,6 +330,18 @@ class Scope {
       );
     }
     return obj[cacheKey];
+  }
+
+  /**
+   * @returns {Map<string | symbol, ProviderNode>}
+   */
+  getProviderNodes() {
+    const nodes = new Map();
+    for (const [key, provider] of this.known) {
+      const info = getProviderNode(key, provider);
+      nodes.set(key, info);
+    }
+    return nodes;
   }
 }
 module.exports = /** @type {typeof import('../typedefs').Scope} */ (Scope);

--- a/lib/typedefs.d.ts
+++ b/lib/typedefs.d.ts
@@ -26,6 +26,25 @@ type SimpleDependencyProvider = (injector: Injector) => unknown;
 type MultiValuedDependencyProvider = Map<string, SimpleDependencyProvider>;
 type DependencyProvider = SimpleDependencyProvider | MultiValuedDependencyProvider;
 
+type SimpleProviderNode = {
+  key: string | symbol,
+  multiValued: false,
+};
+
+type MultiValuedProviderNode = {
+  key: string | symbol,
+  multiValued: true,
+  indices: Map<string, SimpleProviderNode>,
+};
+
+type ProviderNode = SimpleProviderNode | MultiValuedProviderNode;
+
+type ScopeNode = {
+  name: string,
+  providers: Map<string | symbol, ProviderNode>,
+  children: ScopeNode[],
+};
+
 declare class Scope {
   constructor(name: string);
 
@@ -41,6 +60,8 @@ declare class Scope {
   has(key: string | symbol): boolean;
   getKeys(): (string | symbol)[];
   getOwnMultiValuedProviders(key: string | symbol): MultiValuedDependencyProvider;
+
+  getProviderNodes(): Map<string | symbol, ProviderNode>;
 }
 
 type Provider = {
@@ -87,6 +108,8 @@ export class Registry {
   getSingletonInjector(): Injector;
   getRequestInjector(request: IncomingMessage, response: ServerResponse): Injector;
   getActionInjector(request: IncomingMessage, response: ServerResponse, action: any): Injector;
+
+  getProviderGraph(): ScopeNode;
 }
 
 export function main(app: App, defaultCommand?: string, argv?: string[]): Promise<void>;

--- a/lib/typedefs.d.ts
+++ b/lib/typedefs.d.ts
@@ -112,4 +112,11 @@ export class Registry {
   getProviderGraph(): ScopeNode;
 }
 
+type CommandConfig<OptionsType> = {
+  name: string;
+  description: string;
+  init: (cmd: import('commander').Command) => void;
+  action: (app: App, options: OptionsType, ...args: any[]) => Promise<number | void>;
+};
+
 export function main(app: App, defaultCommand?: string, argv?: string[]): Promise<void>;

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -16,7 +16,7 @@ describe('main', () => {
     const { stdout } = await execFile('node', [CLI, '--help'], {
       cwd: PROJECT_PATH,
     });
-    expect(stdout).include('start [options]  Launch all the things');
+    expect(stdout).match(/start \[options\]\s+Launch all the things/);
   });
 
   it('exits with the code returned from commands', async () => {


### PR DESCRIPTION
The main idea here is that we can remember where dependencies were registered and expose the full dependency tree as an inspectable data structure to build additional tooling on top of.