### PR TITLE
Convenience API to set an instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,11 @@ registry.singleton.setFactory(
 registry.singleton.setFactory('pid', null, () => process.pid);
 ```
 
+#### `scope.setValue(key, value)`
+
+A convenience method for when a factory would always return the same value,
+especially handy for things in the `singleton` scope.
+
 ### `main(app, defaultCommand = 'start', argv = process.argv)`
 
 1. Run `app.initialize()`.

--- a/lib/registry/scope.js
+++ b/lib/registry/scope.js
@@ -231,27 +231,11 @@ class Scope {
   /**
    * @template T
    * @param {string} query
-   * @param {string[] | null} deps
-   * @param {(deps?: any) => T} factory
+   * @param {(injector: Injector) => T} provider
    */
-  setFactory(query, deps, factory) {
+  setProvider(query, provider) {
     const dependeny = parseDependencyQuery(query);
     const key = dependeny.key;
-    const parsedDeps =
-      deps && deps.length ? deps.map(parseDependencyQuery) : null;
-
-    const provider = parsedDeps
-      ? (/** @type {Injector} */ injector) => {
-          const resolvedDeps = Object.create(null);
-          parsedDeps.forEach(parsedDep => {
-            resolvedDeps[parsedDep.key] = injector.get(parsedDep);
-          });
-          return factory(resolvedDeps);
-        }
-      : () => factory();
-
-    // Annotate provider
-    Object.assign(provider, getProviderMetaData(this.setFactory, parsedDeps));
 
     if (dependeny.multiValued) {
       return void this.multiSet(dependeny, provider);
@@ -273,6 +257,44 @@ class Scope {
     }
 
     this.known.set(key, provider);
+  }
+
+  /**
+   * @template T
+   * @param {string} query
+   * @param {T} value
+   */
+  setValue(query, value) {
+    const provider = () => value;
+    Object.assign(provider, getProviderMetaData(this.setValue, null));
+
+    this.setProvider(query, provider);
+  }
+
+  /**
+   * @template T
+   * @param {string} query
+   * @param {string[] | null} deps
+   * @param {(deps?: any) => T} factory
+   */
+  setFactory(query, deps, factory) {
+    const parsedDeps =
+      deps && deps.length ? deps.map(parseDependencyQuery) : null;
+
+    const provider = parsedDeps
+      ? (/** @type {Injector} */ injector) => {
+          const resolvedDeps = Object.create(null);
+          parsedDeps.forEach(parsedDep => {
+            resolvedDeps[parsedDep.key] = injector.get(parsedDep);
+          });
+          return factory(resolvedDeps);
+        }
+      : () => factory();
+
+    // Annotate provider
+    Object.assign(provider, getProviderMetaData(this.setFactory, parsedDeps));
+
+    this.setProvider(query, provider);
   }
 
   /**

--- a/lib/typedefs.d.ts
+++ b/lib/typedefs.d.ts
@@ -51,6 +51,7 @@ declare class Scope {
   readonly name: string;
 
   setFactory<T>(query: string | symbol, deps: string[] | null, factory: (deps?: any) => T): void;
+  setValue<T>(query: string | symbol, value: T): void;
 
   createInjector(init: Map<any, any>, parent?: Injector): Injector;
   getCachedInjector(target: object): Injector;

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -60,7 +60,11 @@ describe('Registry', () => {
     const res = /** @type {any} */ ({});
     const action = /** @type {any} */ ({});
 
+    const CONST_VALUE = { constValue: true };
+
     beforeEach(() => {
+      registry.singleton.setValue('constValue', CONST_VALUE);
+
       registry.request.setFactory('byReq', [], () => ({ byReq: true }));
       registry.request.setFactory(Symbol('byReq'), null, () => ({
         uniqueByReq: true,
@@ -75,11 +79,19 @@ describe('Registry', () => {
 
       assert.deepEqual(['get', 'keys'], Object.keys(provider));
       assert.deepEqual(
-        ['action', 'byAction', 'byReq', 'request', 'response'],
+        ['action', 'byAction', 'byReq', 'constValue', 'request', 'response'],
         provider
           .keys()
           .filter(k => typeof k === 'string')
           .sort()
+      );
+    });
+
+    it('has a short-hand for setting a constant value', () => {
+      registry.singleton.has('constValue');
+      assert.equal(
+        registry.getSingletonInjector().get('constValue'),
+        CONST_VALUE
       );
     });
 
@@ -107,12 +119,12 @@ describe('Registry', () => {
     it('can be inspected', () => {
       const injector = registry.getActionInjector(req, res, action);
       assert.equal(
-        'Injector<action> { action, byAction, request, response, byReq, Symbol(byReq) }',
+        'Injector<action> { action, byAction, request, response, byReq, Symbol(byReq), constValue }',
         inspect(injector)
       );
       const provider = injector.getProvider();
       assert.equal(
-        'Provider { Injector<action> { action, byAction, request, response, byReq, Symbol(byReq) } }',
+        'Provider { Injector<action> { action, byAction, request, response, byReq, Symbol(byReq), constValue } }',
         inspect(provider)
       );
     });


### PR DESCRIPTION
We keep running into places where we have code like this:

```js
registry.singleton.setFactory('simpleStaticThing', null, () => simpleStaticThing);
```

This can now be written as:

```js
registry.singleton.setValue('simpleStaticThing', simpleStaticThing);
```