### PR TITLE
add `key` property to dep key errs

### DIFF
--- a/lib/registry/injector.js
+++ b/lib/registry/injector.js
@@ -235,6 +235,7 @@ class Injector {
     throw Object.assign(new Error(`Unknown dependency key ${toString(key)}`), {
       code: 'INVALID_DEPENDENCY_KEY',
       scope: this.scope.name,
+      key,
     });
   }
 


### PR DESCRIPTION
This will make providing more useful errors for known missing keys
cleaner.


---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.0.1)_