### PR TITLE
stop using `esm` for ES module loading

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 /node_modules
 /tmp
+/lib/esm/import.js

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,3 @@
 {
-  "extends": "groupon/node8"
+  "extends": "groupon/node10"
 }

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: node_js
 node_js:
   - '8'
   - '10'
+  - '12'
 env:
   - NODE_OPTIONS=
   - NODE_OPTIONS=--experimental-modules
@@ -15,6 +16,4 @@ deploy:
     skip_cleanup: true
     'on':
       branch: master
-      node: '10'
-before_install:
-  - npm i -g npm@^6
+      node: '12'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,13 @@ language: node_js
 node_js:
   - '8'
   - '10'
+env:
+  - NODE_OPTIONS=
+  - NODE_OPTIONS=--experimental-modules
+matrix:
+  exclude:
+  - node_js: '8'
+    env: NODE_OPTIONS=--experimental-modules
 deploy:
   - provider: script
     script: ./node_modules/.bin/nlm release

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     env: NODE_OPTIONS=--experimental-modules
 deploy:
   - provider: script
-    script: ./node_modules/.bin/nlm release
+    script: npx nlm release
     skip_cleanup: true
     'on':
       branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,10 @@
 language: node_js
 node_js:
-  - '8'
   - '10'
   - '12'
 env:
   - NODE_OPTIONS=
   - NODE_OPTIONS=--experimental-modules
-matrix:
-  exclude:
-  - node_js: '8'
-    env: NODE_OPTIONS=--experimental-modules
 deploy:
   - provider: script
     script: npx nlm release

--- a/README.md
+++ b/README.md
@@ -122,6 +122,11 @@ This function returns an array with one entry for each interface file:
   relative to the app's root directory.
 * `group`: The directory the file was found in.
 
+Note that `.mjs` file support requires you to be using a version of node with
+builtin support for ES Modules.  Currently this is Node 10+ with
+the `--experimental-modules` flag.  Node 10.x seems to experience
+segfaults under certain conditions, so we recommend 12+.
+
 ### Registry
 
 A set of three scopes, in order of nesting:

--- a/lib/esm/import.js
+++ b/lib/esm/import.js
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2019, Groupon
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+'use strict';
+
+// put this in its own file so that it can barf on require if needed
+
+/**
+ * @param {string} id
+ * @returns {Promise<any>}
+ */
+module.exports = id => import(id);

--- a/lib/esm/index.js
+++ b/lib/esm/index.js
@@ -40,7 +40,7 @@ try {
   importESM = require('./import');
 } catch (err) {
   debug('failed to load esm import: ', err);
-  importESM = () => Promise.reject(err);
+  importESM = () => Promise.reject(new Error('Not supported'));
 }
 
 exports.importESM = importESM;

--- a/lib/esm/index.js
+++ b/lib/esm/index.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2019, Groupon
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ *
+ * Neither the name of GROUPON nor the names of its contributors may be
+ * used to endorse or promote products derived from this software without
+ * specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+ * IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+ * TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+ * HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+ * SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+ * TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+ * LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+ * NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+'use strict';
+
+const debug = require('debug')('esm');
+
+/** @type {(id: string) => Promise<any>} */
+let importESM;
+try {
+  importESM = require('./import');
+} catch (err) {
+  debug('failed to load esm import: ', err);
+  importESM = () => Promise.reject(err);
+}
+
+exports.importESM = importESM;
+exports.supportsESM = () =>
+  importESM('../../package.json').then(() => true, () => false);

--- a/lib/project.js
+++ b/lib/project.js
@@ -33,7 +33,8 @@
 'use strict';
 
 const path = require('path');
-const Module = require('module');
+// @ts-ignore
+const { createRequireFromPath, createRequire } = require('module');
 const util = require('util');
 const { URL } = require('url');
 
@@ -43,9 +44,9 @@ const globCallback = require('glob');
 
 const glob = util.promisify(globCallback);
 
-// @ts-ignore
-const rawModulePaths = Module['_nodeModulePaths'];
-const getModulePaths = /** @type {(from: string) => string[]} */ (rawModulePaths);
+// createRequireFromPath is deprecated Node 10.x; createRequire is official 12+
+/** @type {typeof createRequireFromPath} */
+const createReq = createRequire || createRequireFromPath;
 
 const { importESM } = require('./esm');
 
@@ -69,14 +70,10 @@ class Project {
     this.root = appDirectory;
 
     const appPath = path.resolve(appDirectory, 'app');
-    this.app = new Module('<app>');
-    this.app.filename = appPath;
-    this.app.paths = getModulePaths(appPath);
+    this.require = createReq(appPath);
 
     const frameworkPath = path.resolve(frameworkDirectory, 'app');
-    this.framework = new Module('<framework>');
-    this.framework.filename = frameworkPath;
-    this.framework.paths = getModulePaths(frameworkPath);
+    this.requireBundled = createReq(frameworkPath);
 
     this._pkgJson = null;
     this._globCache = {};
@@ -172,7 +169,7 @@ class Project {
     try {
       return await importESM(
         /^\.\.?\//.test(id)
-          ? new URL(id, `file://${this.app.filename}`).toString()
+          ? new URL(id, `file://${this.root}/app`).toString()
           : id
       );
     } catch (err) {
@@ -202,16 +199,6 @@ class Project {
   /**
    * @template T
    * @param {string} id
-   * @returns {T}
-   */
-  require(id) {
-    debug('require', id);
-    return this.app.require(id);
-  }
-
-  /**
-   * @template T
-   * @param {string} id
    * @returns {T | null}
    */
   requireOrNull(id) {
@@ -225,15 +212,6 @@ class Project {
 
       return null;
     }
-  }
-
-  /**
-   * @template T
-   * @param {string} id
-   * @returns {T}
-   */
-  requireBundled(id) {
-    return this.framework.require(id);
   }
 
   /**

--- a/lib/project.js
+++ b/lib/project.js
@@ -205,6 +205,7 @@ class Project {
    * @returns {T}
    */
   require(id) {
+    debug('require', id);
     return this.app.require(id);
   }
 

--- a/lib/project.js
+++ b/lib/project.js
@@ -35,10 +35,9 @@
 const path = require('path');
 const Module = require('module');
 const util = require('util');
+const { URL } = require('url');
 
 const debug = require('debug')('nilo:project');
-// @ts-ignore
-const esm = require('esm');
 // @ts-ignore
 const globCallback = require('glob');
 
@@ -48,27 +47,18 @@ const glob = util.promisify(globCallback);
 const rawModulePaths = Module['_nodeModulePaths'];
 const getModulePaths = /** @type {(from: string) => string[]} */ (rawModulePaths);
 
+const { importESM } = require('./esm');
+
+/**
+ * @param {string} reSTR
+ */
+function escapeRE(reSTR) {
+  return reSTR.replace(/[$^*()+\[\]{}\\|.?]/g, '\\$&');
+}
+
 /**
  * @typedef {import('./typedefs').InterfaceFile} InterfaceFile
  */
-
-/**
- * @param {object} esmResult
- * @param {string} specifier
- */
-function guessNamespace(esmResult, specifier) {
-  if (specifier.endsWith('.mjs')) return esmResult;
-
-  // "Heuristic" to figure out if it kinda looks like a namespace
-  if (
-    esmResult !== null &&
-    typeof esmResult === 'object' &&
-    'default' in esmResult
-  )
-    return esmResult;
-
-  return { default: esmResult };
-}
 
 class Project {
   /**
@@ -91,27 +81,12 @@ class Project {
     this._pkgJson = null;
     this._globCache = {};
     this._globStatCache = {};
-
-    this._importESM = esm(this.app, {
-      cjs: {
-        cache: false,
-        esModule: false,
-        extensions: false,
-        mutableNamespace: false,
-        namedExports: false,
-        paths: false,
-        vars: false,
-        dedefault: false,
-        topLevelReturn: false,
-      },
-      mode: 'strict',
-    });
   }
 
   /**
    * @param {string} pattern
    * @param {object} [options]
-   * @returns {string[]}
+   * @returns {Promise<string[]>}
    */
   cachedGlob(pattern, options = {}) {
     return glob(
@@ -188,9 +163,22 @@ class Project {
    * @param {string} id
    * @returns {Promise<unknown>}
    */
-  import(id) {
-    const esmResult = this._importESM(id);
-    return guessNamespace(esmResult, id);
+  async import(id) {
+    debug('import', id);
+    // if it's a package spec, assume we can't load it as a ES module
+    // for now
+    if (!/^(\.\.?)?\//.test(id)) return { default: this.require(id) };
+
+    try {
+      return await importESM(
+        /^\.\.?\//.test(id)
+          ? new URL(id, `file://${this.app.filename}`).toString()
+          : id
+      );
+    } catch (err) {
+      if (err.message !== 'Not supported') throw err;
+      return { default: this.require(id) };
+    }
   }
 
   /**
@@ -204,7 +192,8 @@ class Project {
       // Still throw errors unrelated to finding the module
       if (e.code !== 'MODULE_NOT_FOUND') throw e;
       // Do *not* ignore failing requires of subsequent files
-      if (!e.message.includes(`'${id}'`)) throw e;
+      const re = new RegExp(`(^|[\\s'"])${escapeRE(id)}([\\s'"]|$)`);
+      if (!re.test(e.message)) throw e;
 
       return null;
     }

--- a/lib/registry/injector.js
+++ b/lib/registry/injector.js
@@ -41,15 +41,7 @@ const { parseDependencyQuery } = require('./query');
 /** @typedef {import('../typedefs').DependencyDescriptor} DependencyDescriptor */
 /** @typedef {import('../typedefs').DependencyQuery} DependencyQuery */
 
-const INSPECT = util.inspect.custom || Symbol.for('nodejs.util.inspect.custom');
-
-/**
- * @param {Injector} injector
- */
-function inspectProvider(injector) {
-  // @ts-ignore
-  return `Provider { ${injector[INSPECT]()} }`;
-}
+const INSPECT = util.inspect.custom;
 
 const PROVIDER_HANDLER = {
   /**
@@ -59,17 +51,14 @@ const PROVIDER_HANDLER = {
   get(injector, key) {
     switch (key) {
       case 'constructor':
-        return injector.constructor;
-
       case 'get':
-        return injector.get;
-
       case 'keys':
-        return injector.keys;
+      case 'scope':
+        return injector[key];
 
-      case INSPECT: {
-        return inspectProvider.bind(null, injector);
-      }
+      case INSPECT:
+        // @ts-ignore
+        return injector[INSPECT];
 
       default:
         return injector.get(key);

--- a/package-lock.json
+++ b/package-lock.json
@@ -756,11 +756,6 @@
       "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
       "dev": true
     },
-    "esm": {
-      "version": "3.2.20",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.20.tgz",
-      "integrity": "sha512-NA92qDA8C/qGX/xMinDGa3+cSPs4wQoFxskRrSnDo/9UloifhONFm4sl4G+JsyCqM007z2K+BfQlH5rMta4K1Q=="
-    },
     "espree": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "commander": "^2.19.0",
     "debug": "^4.1.1",
-    "esm": "^3.2.20",
     "glob": "^7.1.3"
   },
   "devDependencies": {

--- a/test/project.test.js
+++ b/test/project.test.js
@@ -58,6 +58,8 @@ module.exports = 'from lib1';
 `,
       };
       if (await supportsESM()) {
+        // eslint-disable-next-line no-console
+        console.log('      [esm support enabled]');
         files['modules/mod1/everywhere.mjs'] = `\
 export default 'from mod1';
 export const namedExport = 'forwarded';

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -26,7 +26,7 @@ function assertThrows(fn) {
  * @param {Error & { code: string }} err
  */
 function assertInvalidError(err) {
-  assert.equal('INVALID_DEPENDENCY_KEY', err.code);
+  assert.equal(err.code, 'INVALID_DEPENDENCY_KEY');
 }
 
 /**
@@ -34,7 +34,7 @@ function assertInvalidError(err) {
  */
 function assertMissingError(err) {
   assert.include(err.message, 'Unknown dependency');
-  assert.equal('INVALID_DEPENDENCY_KEY', err.code);
+  assert.equal(err.code, 'INVALID_DEPENDENCY_KEY');
 }
 
 /**
@@ -42,7 +42,7 @@ function assertMissingError(err) {
  */
 function assertDuplicateError(err) {
   assert.include(err.message, 'already been registered');
-  assert.equal('DUPLICATE_DEPENDENCY_KEY', err.code);
+  assert.equal(err.code, 'DUPLICATE_DEPENDENCY_KEY');
 }
 
 describe('Registry', () => {
@@ -97,9 +97,9 @@ describe('Registry', () => {
 
     it('exposes built-ins', () => {
       const injector = registry.getActionInjector(req, res, action);
-      assert.equal(req, injector.get('request'));
-      assert.equal(res, injector.get('response'));
-      assert.equal(action, injector.get('action'));
+      assert.equal(injector.get('request'), req);
+      assert.equal(injector.get('response'), res);
+      assert.equal(injector.get('action'), action);
     });
 
     it('caches deps by request but not by action', () => {
@@ -119,13 +119,13 @@ describe('Registry', () => {
     it('can be inspected', () => {
       const injector = registry.getActionInjector(req, res, action);
       assert.equal(
-        'Injector<action> { action, byAction, request, response, byReq, Symbol(byReq), constValue }',
-        inspect(injector)
+        inspect(injector),
+        'Injector<action> { action, byAction, request, response, byReq, Symbol(byReq), constValue }'
       );
       const provider = injector.getProvider();
       assert.equal(
-        'Provider { Injector<action> { action, byAction, request, response, byReq, Symbol(byReq), constValue } }',
-        inspect(provider)
+        inspect(provider),
+        'Provider { Injector<action> { action, byAction, request, response, byReq, Symbol(byReq), constValue } }'
       );
     });
   });
@@ -138,8 +138,8 @@ describe('Registry', () => {
       ])
         .getActionInjector()
         .getProvider();
-      assert.equal(99, deps.blah);
-      assert.equal(42, deps.answer);
+      assert.equal(deps.blah, 99);
+      assert.equal(deps.answer, 42);
     });
   });
 
@@ -203,12 +203,12 @@ describe('Registry', () => {
 
     it('supports option object syntax', () => {
       assert.equal(
-        undefined,
-        singleton.get({ key: 'missing', optional: true, multiValued: false })
+        singleton.get({ key: 'missing', optional: true, multiValued: false }),
+        undefined
       );
       assert.equal(
-        EXISTING,
-        singleton.get({ key: 'existing', optional: true, multiValued: false })
+        singleton.get({ key: 'existing', optional: true, multiValued: false }),
+        EXISTING
       );
     });
 
@@ -318,17 +318,17 @@ describe('Registry', () => {
 
     it('refuses to retrieve a multi-values key when requesting a single value', () => {
       const err = assertThrows(() => singleton.get('single'));
-      assert.equal('INCOMPATIBLE_DEPENDENCY_KEY', err.code);
+      assert.equal(err.code, 'INCOMPATIBLE_DEPENDENCY_KEY');
 
       assert.equal(
-        'INCOMPATIBLE_DEPENDENCY_KEY',
-        assertThrows(() => singleton.getProvider()['single']).code
+        assertThrows(() => singleton.getProvider()['single']).code,
+        'INCOMPATIBLE_DEPENDENCY_KEY'
       );
     });
 
     it('refuses to retrieve a normal key when requesting as multi-valued', () => {
       const err = assertThrows(() => singleton.get('simple[]'));
-      assert.equal('INCOMPATIBLE_DEPENDENCY_KEY', err.code);
+      assert.equal(err.code, 'INCOMPATIBLE_DEPENDENCY_KEY');
     });
 
     it('resolves to an empty list if no provider is known', () => {
@@ -353,7 +353,7 @@ describe('Registry', () => {
 
     it('exposes the index names of the list items', () => {
       const multi = /** @type {{ c: string }} */ (request.get('multi[]'));
-      assert.equal('r.c', multi.c);
+      assert.equal(multi.c, 'r.c');
     });
 
     it('does shadowing per index', () => {

--- a/test/registry.test.js
+++ b/test/registry.test.js
@@ -125,7 +125,7 @@ describe('Registry', () => {
       const provider = injector.getProvider();
       assert.equal(
         inspect(provider),
-        'Provider { Injector<action> { action, byAction, request, response, byReq, Symbol(byReq), constValue } }'
+        'Injector<action> { action, byAction, request, response, byReq, Symbol(byReq), constValue }'
       );
     });
   });


### PR DESCRIPTION
BREAKING CHANGE: now if you want to use `.mjs` files, you need to run
with `NODE_OPTIONS=--experimental-modules` on Node 10.x+.  Also, native
ES module loading is NOT compatible with coffeescript/register

---
_This PR was started by: [git wf pr](https://github.com/groupon/git-workflow/releases/tag/v1.0.3)_